### PR TITLE
Add imaginary.stream; replace hashvault with nodes.rentals

### DIFF
--- a/app/src/main/java/com/m2049r/xmrwallet/util/AppPreferences.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/AppPreferences.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 public class AppPreferences {
     private static final String DEFAULT_DAEMONLIST_MAINNET =
-            "doopool.xyz:22020;pool.loki.hashvault.pro;daemons.cryptopool.space;node.loki-pool.com:18081;node.lokipool.cloud:18081";
+            "doopool.xyz:22020;nodes.hashvault.pro;daemons.cryptopool.space;node.loki-pool.com:18081;node.lokipool.cloud:18081;imaginary.stream";
 
     private static final String DEFAULT_DAEMONLIST_STAGENET =
             "nari.blockfoundry.org:10610";


### PR DESCRIPTION
imaginary.stream: IPv4+IPv6 accessible, hosted in Canada.

~~hashvault doesn't appear to be responding; changing it to
rpc.nodes.rentals (as was done in the gui in loki-project/loki-gui#50).~~

The hashvault public node hostname changed; I've updated the PR to fix it.