### PR TITLE
Fix blink transaction construction

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply from: './gradle_helpers/git-utils.gradle'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '29.0.2'
     defaultConfig {
         applicationId 'network.loki.wallet'
         minSdkVersion 21

--- a/app/src/main/cpp/monerujo.cpp
+++ b/app/src/main/cpp/monerujo.cpp
@@ -921,10 +921,9 @@ Java_com_m2049r_xmrwallet_model_Wallet_createTransactionJ(JNIEnv *env, jobject i
 
     const char *_dst_addr = env->GetStringUTFChars(dst_addr, NULL);
     const char *_payment_id = env->GetStringUTFChars(payment_id, NULL);
-    Bitmonero::PendingTransaction::Priority _priority =
-            static_cast<Bitmonero::PendingTransaction::Priority>(priority);
     Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
 
+    uint32_t _priority = (uint32_t)priority;
     Bitmonero::PendingTransaction *tx = wallet->createTransaction(_dst_addr, _payment_id,
                                                                   amount, (uint32_t) mixin_count,
                                                                   _priority,
@@ -944,8 +943,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_createSweepTransaction(JNIEnv *env, jobje
 
     const char *_dst_addr = env->GetStringUTFChars(dst_addr, NULL);
     const char *_payment_id = env->GetStringUTFChars(payment_id, NULL);
-    Bitmonero::PendingTransaction::Priority _priority =
-            static_cast<Bitmonero::PendingTransaction::Priority>(priority);
+    uint32_t _priority = (uint32_t)priority;
     Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
 
     Monero::optional<uint64_t> empty;

--- a/app/src/main/java/com/m2049r/xmrwallet/model/PendingTransaction.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/model/PendingTransaction.java
@@ -37,18 +37,18 @@ public class PendingTransaction {
 
     public enum Priority {
         Slow(1),
-        Blink(0x626c6e6b);
+        Blink(5);
 
         public static Priority fromInteger(int n) {
-            if (n == Blink.getValue()) return Priority.Blink;
-            return Priority.Slow;
+            if (n == Slow.getValue()) return Priority.Slow;
+            return Priority.Blink;
         }
 
         public static Priority fromString(String string) {
             try {
                 return Priority.valueOf(string);
             } catch (Exception e) {
-                return Priority.Slow;
+                return Priority.Blink;
             }
         }
 

--- a/app/src/main/java/com/m2049r/xmrwallet/model/Wallet.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/model/Wallet.java
@@ -321,7 +321,7 @@ public class Wallet {
                                 accountIndex) :
                         createTransactionJ(dst_addr, payment_id, amount, mixin_count, _priority,
                                 accountIndex));
-        pendingTransaction = new PendingTransaction(txHandle, priority == PendingTransaction.Priority.Blink);
+        pendingTransaction = new PendingTransaction(txHandle, priority != PendingTransaction.Priority.Slow);
         return pendingTransaction;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/external-libs/monero/include/wallet2_api.h
+++ b/external-libs/monero/include/wallet2_api.h
@@ -77,14 +77,6 @@ struct PendingTransaction
         Status_Critical
     };
 
-    enum Priority {
-        Priority_Default = 0,
-        Priority_Low = 1,
-        Priority_Medium = 2,
-        Priority_High = 3,
-        Priority_Last
-    };
-
     virtual ~PendingTransaction() = 0;
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;
@@ -824,16 +816,18 @@ struct Wallet
      * \param mixin_count       mixin count. if 0 passed, wallet will use default value
      * \param subaddr_account   subaddress account from which the input funds are taken
      * \param subaddr_indices   set of subaddress indices to use for transfer or sweeping. if set empty, all are chosen when sweeping, and one or more are automatically chosen when transferring. after execution, returns the set of actually used indices
-     * \param priority
+     * \param priority          set a priority for the transaction. Accepted Values are: default (0), or 0-5 for: default, unimportant, normal, elevated, priority, blink.
      * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                          after object returned
      */
 
-    virtual PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
-                                                   optional<uint64_t> amount, uint32_t mixin_count,
-                                                   PendingTransaction::Priority = PendingTransaction::Priority_Low,
-                                                   uint32_t subaddr_account = 0,
-                                                   std::set<uint32_t> subaddr_indices = {}) = 0;
+    virtual PendingTransaction *createTransaction(const std::string &dst_addr,
+                                                  const std::string &payment_id,
+                                                  optional<uint64_t> amount,
+                                                  uint32_t mixin_count,
+                                                  uint32_t priority                  = 0,
+                                                  uint32_t subaddr_account           = 0,
+                                                  std::set<uint32_t> subaddr_indices = {}) = 0;
 
     /*!
      * \brief createSweepUnmixableTransaction creates transaction with unmixable outputs.
@@ -1256,7 +1250,6 @@ struct WalletManagerBase
     //! checks for an update and returns version, hash and url
     static std::tuple<bool, std::string, std::string, std::string, std::string> checkUpdates(const std::string &software, std::string subdir);
 };
-
 
 struct WalletManagerFactory
 {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,3 @@ org.gradle.jvmargs=-Xmx2048m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-# keep build timestamps in APK
-android.keepTimestampsInApk = true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 23 14:15:55 AEDT 2020
+#Wed Jun 24 14:21:31 ADT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
The blink priority value was still set to the old magic value, and so the required burn amount wasn't getting added to the transaction data (and thus was getting rejected by blink quorums).

This commit fixes it; it also slightly changes the logic to match loki-core: we have "slow" priority, and anything else is blink.  (In practice this shouldn't matter since only the two priorities--slow and blink--weere exposed, but just makes the logic consistent).

(It also changes a few random project settings that were needed to build it in the latest version of android studio).

Fixes #33 