### PR TITLE
Remove the maximum amount limit

### DIFF
--- a/app/src/main/cpp/monerujo.cpp
+++ b/app/src/main/cpp/monerujo.cpp
@@ -921,10 +921,9 @@ Java_com_m2049r_xmrwallet_model_Wallet_createTransactionJ(JNIEnv *env, jobject i
 
     const char *_dst_addr = env->GetStringUTFChars(dst_addr, NULL);
     const char *_payment_id = env->GetStringUTFChars(payment_id, NULL);
-    Bitmonero::PendingTransaction::Priority _priority =
-            static_cast<Bitmonero::PendingTransaction::Priority>(priority);
     Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
 
+    uint32_t _priority = (uint32_t)priority;
     Bitmonero::PendingTransaction *tx = wallet->createTransaction(_dst_addr, _payment_id,
                                                                   amount, (uint32_t) mixin_count,
                                                                   _priority,
@@ -944,8 +943,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_createSweepTransaction(JNIEnv *env, jobje
 
     const char *_dst_addr = env->GetStringUTFChars(dst_addr, NULL);
     const char *_payment_id = env->GetStringUTFChars(payment_id, NULL);
-    Bitmonero::PendingTransaction::Priority _priority =
-            static_cast<Bitmonero::PendingTransaction::Priority>(priority);
+    uint32_t _priority = (uint32_t)priority;
     Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
 
     Monero::optional<uint64_t> empty;

--- a/app/src/main/java/com/m2049r/xmrwallet/widget/ExchangeView.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/widget/ExchangeView.java
@@ -250,9 +250,6 @@ public class ExchangeView extends LinearLayout {
 
     }
 
-    final static double MAX_AMOUNT_XMR = 1000;
-    final static double MAX_AMOUNT_NOTXMR = 100000;
-
     public boolean checkEnteredAmount() {
         boolean ok = true;
         Timber.d("checkEnteredAmount");
@@ -260,13 +257,7 @@ public class ExchangeView extends LinearLayout {
         if (!amountEntry.isEmpty()) {
             try {
                 double a = Double.parseDouble(amountEntry);
-                double maxAmount = (getCurrencyA() == 0) ? MAX_AMOUNT_XMR : MAX_AMOUNT_NOTXMR;
-                if (a > (maxAmount)) {
-                    etAmount.setError(getResources().
-                            getString(R.string.receive_amount_too_big,
-                                    String.format(Locale.US, "%,.0f", maxAmount)));
-                    ok = false;
-                } else if (a < 0) {
+                if (a < 0) {
                     etAmount.setError(getResources().getString(R.string.receive_amount_negative));
                     ok = false;
                 }

--- a/external-libs/monero/include/wallet2_api.h
+++ b/external-libs/monero/include/wallet2_api.h
@@ -77,14 +77,6 @@ struct PendingTransaction
         Status_Critical
     };
 
-    enum Priority {
-        Priority_Default = 0,
-        Priority_Low = 1,
-        Priority_Medium = 2,
-        Priority_High = 3,
-        Priority_Last
-    };
-
     virtual ~PendingTransaction() = 0;
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;
@@ -824,16 +816,18 @@ struct Wallet
      * \param mixin_count       mixin count. if 0 passed, wallet will use default value
      * \param subaddr_account   subaddress account from which the input funds are taken
      * \param subaddr_indices   set of subaddress indices to use for transfer or sweeping. if set empty, all are chosen when sweeping, and one or more are automatically chosen when transferring. after execution, returns the set of actually used indices
-     * \param priority
+     * \param priority          set a priority for the transaction. Accepted Values are: default (0), or 0-5 for: default, unimportant, normal, elevated, priority, blink.
      * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                          after object returned
      */
 
-    virtual PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
-                                                   optional<uint64_t> amount, uint32_t mixin_count,
-                                                   PendingTransaction::Priority = PendingTransaction::Priority_Low,
-                                                   uint32_t subaddr_account = 0,
-                                                   std::set<uint32_t> subaddr_indices = {}) = 0;
+    virtual PendingTransaction *createTransaction(const std::string &dst_addr,
+                                                  const std::string &payment_id,
+                                                  optional<uint64_t> amount,
+                                                  uint32_t mixin_count,
+                                                  uint32_t priority                  = 0,
+                                                  uint32_t subaddr_account           = 0,
+                                                  std::set<uint32_t> subaddr_indices = {}) = 0;
 
     /*!
      * \brief createSweepUnmixableTransaction creates transaction with unmixable outputs.
@@ -1256,7 +1250,6 @@ struct WalletManagerBase
     //! checks for an update and returns version, hash and url
     static std::tuple<bool, std::string, std::string, std::string, std::string> checkUpdates(const std::string &software, std::string subdir);
 };
-
 
 struct WalletManagerFactory
 {


### PR DESCRIPTION
1000 isn't that much, but even if it was there's no technical reason at
all to have such a limit.  (If you are a whale and want to sweep your
wallet, why would we prevent that?)

Fixes #32 - I didn't add a setting for this partly because it's beyond my Java experience, but also our other wallets don't have an arbitrary sending limit so I don't see any particular reason the Android wallet should.